### PR TITLE
fix function generation

### DIFF
--- a/examples/basic_multi_supply/main.go
+++ b/examples/basic_multi_supply/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/skjdfhkskjds/depinject"
+	"github.com/skjdfhkskjds/depinject/examples"
+)
+
+// This example is identical to the basic example but supplies
+// multiple values into the container instead.
+
+func main() {
+	container := depinject.NewContainer()
+
+	// Supply a value into the container directly.
+	if err := container.Supply(&examples.Foo{}, &examples.Bar{}); err != nil {
+		panic(err)
+	}
+
+	// Provide a set of constructors into the container.
+	if err := container.Provide(
+		examples.NewFooBar,
+	); err != nil {
+		panic(err)
+	}
+
+	// Invoke a function with the dependencies injected
+	// to retrieve the FooBar instance.
+	var fooBar *examples.FooBar
+	if err := container.Invoke(&fooBar); err != nil {
+		panic(err)
+	}
+	fooBar.Print()
+}

--- a/internal/depinject/invoke.go
+++ b/internal/depinject/invoke.go
@@ -6,6 +6,8 @@ import (
 	"github.com/skjdfhkskjds/depinject/internal/depinject/types/errors"
 )
 
+const invokeErrorName = "invoke"
+
 // Invoke resolves the container and extracts the resulting
 // values from the container.
 // It returns an error if the container is invalid (not resolvable), or
@@ -49,12 +51,12 @@ func (c *Container) invoke(output any) error {
 	// Get the value of the output type in the container
 	node, err := c.registry.Get(outputType)
 	if err != nil {
-		return errors.New(err, outputType.String())
+		return errors.New(err, invokeErrorName, outputType.String())
 	}
 
 	value, err := node.ValueOf(outputType)
 	if err != nil {
-		return errors.New(err, outputType.String())
+		return errors.New(err, invokeErrorName, outputType.String())
 	}
 
 	// Assign the value to the output

--- a/internal/depinject/provide.go
+++ b/internal/depinject/provide.go
@@ -1,8 +1,11 @@
 package depinject
 
 import (
+	"github.com/skjdfhkskjds/depinject/internal/depinject/types/errors"
 	"github.com/skjdfhkskjds/depinject/internal/depinject/types/node"
 )
+
+const provideErrorName = "provide"
 
 // Provide adds a set of constructors to the container.
 // It returns an error if any of the constructors are invalid,
@@ -26,9 +29,9 @@ func (c *Container) provide(constructor any) error {
 		return err
 	}
 
-	if err = c.graph.AddVertex(node); err != nil {
-		return err
+	if err = c.addNode(node); err != nil {
+		return errors.New(err, provideErrorName, node.ID())
 	}
 
-	return c.registry.Register(node)
+	return nil
 }

--- a/internal/depinject/supply.go
+++ b/internal/depinject/supply.go
@@ -1,8 +1,14 @@
 package depinject
 
 import (
-	"reflect"
+	"fmt"
+
+	"github.com/skjdfhkskjds/depinject/internal/depinject/types/errors"
+	"github.com/skjdfhkskjds/depinject/internal/depinject/types/node"
+	"github.com/skjdfhkskjds/depinject/internal/reflect"
 )
+
+const supplyErrorName = "supply"
 
 // Supply is a helper function that allows for the injection of
 // values into the container. It is useful for injecting values
@@ -18,16 +24,20 @@ func (c *Container) Supply(values ...any) error {
 }
 
 func (c *Container) supply(value any) error {
-	// Use reflect to get the type and value of the supplied value
-	valueType := reflect.TypeOf(value)
-
 	// Generate a function that returns the supplied value
-	fn := reflect.MakeFunc(
-		reflect.FuncOf(nil, []reflect.Type{valueType}, false),
-		func(args []reflect.Value) []reflect.Value {
-			return []reflect.Value{reflect.ValueOf(value)}
-		},
+	fn, err := reflect.NewFunc(
+		nil,
+		[]reflect.Value{reflect.ValueOf(value)},
 	)
+	if err != nil {
+		return errors.New(err, supplyErrorName, reflect.TypeOf(value).String())
+	}
 
-	return c.Provide(fn.Interface())
+	node := node.NewFromFunc(fn)
+	if err = c.addNode(node); err != nil {
+		fmt.Println("NODE NAME", node.ID())
+		return errors.New(err, supplyErrorName, reflect.TypeOf(value).String())
+	}
+
+	return nil
 }

--- a/internal/depinject/types/errors/errors.go
+++ b/internal/depinject/types/errors/errors.go
@@ -11,14 +11,18 @@ var _ error = (*Error)(nil)
 type Error struct {
 	root error
 
+	sourceName    string
 	resolvingType string
 	args          []any
 }
 
 // New creates a new error.
-func New(root error, resolvingType string, args ...any) *Error {
+func New(
+	root error, sourceName, resolvingType string, args ...any,
+) *Error {
 	return &Error{
 		root:          root,
+		sourceName:    sourceName,
 		resolvingType: resolvingType,
 		args:          args,
 	}
@@ -26,7 +30,8 @@ func New(root error, resolvingType string, args ...any) *Error {
 
 func (e *Error) Error() string {
 	var msg = fmt.Sprintf(
-		"error while resolving %s: %s",
+		"error in %s: failed to resolve %s: %s",
+		e.sourceName,
 		e.resolvingType,
 		e.root.Error(),
 	)

--- a/internal/depinject/types/node/errors.go
+++ b/internal/depinject/types/node/errors.go
@@ -12,4 +12,11 @@ var (
 	// ErrMultipleImplementations is returned when multiple implementations
 	// of an interface are found.
 	ErrMultipleImplementations = errors.New("multiple implementations found")
+
+	// ErrDuplicateOutput is returned when a duplicate output is found.
+	ErrDuplicateOutput = errors.New("duplicate output")
+)
+
+const (
+	registryErrorName = "registry"
 )

--- a/internal/depinject/types/node/node.go
+++ b/internal/depinject/types/node/node.go
@@ -19,7 +19,7 @@ type Node struct {
 
 // New creates a new node.
 func New(constructor any) (*Node, error) {
-	fn, err := reflect.NewFunc(constructor)
+	fn, err := reflect.WrapFunc(constructor)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +29,15 @@ func New(constructor any) (*Node, error) {
 		outputs:     make(map[reflect.Type]reflect.Value),
 		constructor: fn,
 	}, nil
+}
+
+// NewFromFunc creates a new node from a reflect.Func.
+func NewFromFunc(fn *reflect.Func) *Node {
+	return &Node{
+		id:          fn.Name,
+		outputs:     make(map[reflect.Type]reflect.Value),
+		constructor: fn,
+	}
 }
 
 // Dependencies returns the dependencies of the node.

--- a/internal/depinject/types/node/registry.go
+++ b/internal/depinject/types/node/registry.go
@@ -1,14 +1,11 @@
 package node
 
 import (
-	stderr "errors"
 	stdreflect "reflect"
 
 	"github.com/skjdfhkskjds/depinject/internal/depinject/types/errors"
 	"github.com/skjdfhkskjds/depinject/internal/reflect"
 )
-
-var ErrDuplicateOutput = stderr.New("duplicate output")
 
 // A Registry is a registry of nodes which stores node
 // data by inferring type associations to the node's outputs
@@ -28,7 +25,7 @@ func NewRegistry() *Registry {
 func (r *Registry) Register(node *Node) error {
 	for _, output := range node.Outputs() {
 		if _, ok := r.nodes[output]; ok {
-			return errors.New(ErrDuplicateOutput, output.String())
+			return errors.New(ErrDuplicateOutput, registryErrorName, output.String())
 		}
 		r.nodes[output] = node
 	}

--- a/internal/reflect/func.go
+++ b/internal/reflect/func.go
@@ -6,6 +6,12 @@ import (
 	"runtime"
 )
 
+const (
+	generatedFuncNamePrefix     = "GeneratedFunc"
+	generatedFuncNameArgsPrefix = "Args"
+	generatedFuncNameRetPrefix  = "Ret"
+)
+
 // A Func is a wrapper around a reflect function value that
 // provides convenience functions to get metadata and execute
 // a function.
@@ -24,9 +30,44 @@ type Func struct {
 	fn reflect.Value
 }
 
-// NewFunc creates a new Func instance from the given function.
+// NewFunc creates a new Func instance from the given argument and return
+// values.
+// It generates a function which when called consumes the specified args
+// and returns the given return values. It assigns this function a name
+// which is formatted as "GeneratedFuncArgs{argTypes...}Ret{retTypes...}".
+func NewFunc(args []Type, ret []Value) (*Func, error) {
+	retTypes := make([]reflect.Type, len(ret))
+	for i, retValue := range ret {
+		retTypes[i] = retValue.Type()
+	}
+
+	fn := reflect.MakeFunc(
+		reflect.FuncOf(nil, retTypes, false),
+		func(args []reflect.Value) []reflect.Value {
+			return ret
+		},
+	)
+
+	name := generatedFuncNamePrefix + generatedFuncNameArgsPrefix
+	for _, argType := range args {
+		name += argType.String()
+	}
+	name += generatedFuncNameRetPrefix
+	for _, retType := range retTypes {
+		name += retType.String()
+	}
+
+	return &Func{
+		Name: name,
+		Args: args,
+		Ret:  retTypes,
+		fn:   fn,
+	}, nil
+}
+
+// WrapFunc wraps an existing go function into a Func instance.
 // It returns an error if the reflect.TypeOf(f) is not a function.
-func NewFunc(f any) (*Func, error) {
+func WrapFunc(f any) (*Func, error) {
 	// Check if f is a function
 	funcType := reflect.TypeOf(f)
 


### PR DESCRIPTION
generates names for generated functions for supply

previously generated functions which are anonymous would all have the empty string as a name and thus cause conflicts with vertex addition to the graph as the ids would conflict on nodes which are intended to supply different values